### PR TITLE
phone number not being valid

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ const App: React.FC = () => {
           <TouchableOpacity
             style={styles.button}
             onPress={() => {
-              const checkValid = phoneInput.current?.isValidNumber();
+              const checkValid = phoneInput.current?.isValidNumber(valid);
               setShowMessage(true);
               setValid(checkValid ? checkValid : false);
             }}
@@ -141,7 +141,7 @@ export default App;
 
 - `getCountryCode`: () => [CountryCode](https://github.com/xcarpentier/react-native-country-picker-modal/blob/master/src/types.ts#L252)
 - `getCallingCode`: () => string | undefined
-- `isValidNumber`: () => boolean
+- `isValidNumber`: (number) => boolean
 
 ## FAQ
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -288,7 +288,7 @@ export default class PhoneInput extends Component<
     | "HK"
     | "AX";
   getCallingCode: () => string | undefined;
-  isValidNumber: () => boolean;
+  isValidNumber: (number: Number) => boolean;
   onSelect: (country: Country) => void;
   onChangeText: (text: string) => void;
   render(): JSX.Element;

--- a/lib/index.js
+++ b/lib/index.js
@@ -52,9 +52,9 @@ export default class PhoneInput extends Component {
     return this.state.code;
   };
 
-  isValidNumber = () => {
+  isValidNumber = (number) => {
     try {
-      const { number, countryCode } = this.state;
+      const { countryCode } = this.state;
       const parsedNumber = phoneUtil.parse(number, countryCode);
       return phoneUtil.isValidNumber(parsedNumber);
     } catch (err) {


### PR DESCRIPTION
When using isValidNumber within onChangeText it gets always the previous value. As a result it always give false on accurate numbers (for example i tried Tunisian number, it has 8 digits, it shows valid only when 7 or 9 digits are typed)