### PR TITLE
added_possibility_to_remove_flag_and_set_placeholder_to_flag_containe…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -105,6 +105,8 @@ export default class PhoneInput extends Component {
       flagButtonStyle,
       containerStyle,
       textContainerStyle,
+      withCountryFlag,
+      withPlaceholder
     } = this.props;
     const { modalVisible, code, countryCode, number, disabled } = this.state;
     return (
@@ -129,7 +131,8 @@ export default class PhoneInput extends Component {
               withEmoji
               withFilter
               withFlag
-              countryCode={countryCode}
+              countryCode={withCountryFlag !==undefined ? withCountryFlag : countryCode}
+              placeholder={withPlaceholder}
               withCallingCode
               disableNativeModal={disabled}
               visible={modalVisible}


### PR DESCRIPTION
Hello, I found that the library doesn't have a possibility to remove the flag icon from the flag container and when you remove the flag icon you have to remove the default placeholder also.

Thank you for the great library

added_possibility_to_remove_flag_and_set_placeholder_to_flag_container withCountryFlag is boolean