### PR TITLE
Function isValidNumber should take a string type

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -288,7 +288,7 @@ export default class PhoneInput extends Component<
     | "HK"
     | "AX";
   getCallingCode: () => string | undefined;
-  isValidNumber: (number: number) => boolean;
+  isValidNumber: (number: string) => boolean;
   onSelect: (country: Country) => void;
   onChangeText: (text: string) => void;
   render(): JSX.Element;


### PR DESCRIPTION
When trying to get the `isValidNumber` working on my TypeScript React Project, I noticed that the function `isValidNumber` required a number type. Converting the `onChangeText` value to Number however never resulted in a valid value.

This is specifically for TypeScript (I forced typescript to stop complaining about the type and accept a String and things played well again).

Issue #10