### PR TITLE
Get disabled value from props inside the constructor

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26,7 +26,7 @@ export default class PhoneInput extends Component {
         : "",
       modalVisible: false,
       countryCode: props.defaultCode ? props.defaultCode : "IN",
-      disabled: false,
+      disabled: props.disabled || false,
     };
   }
 


### PR DESCRIPTION
There was a bug with previous version when `disabled={true}`.

In the first render disabled value starts in `false` and the input is editable.

Now, i change it and the disabled initial value is taken from props inside the constructor.

Thanks for the library!