### PR TITLE
Support placeholderTextColor prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ const App: React.FC = () => {
             ref={phoneInput}
             defaultValue={value}
             defaultCode="DM"
+            placeholder="Mobile Number"
+            placeholderTextColor="rgba(0,0,0,0.35)"
             layout="first"
             onChangeText={(text) => {
               setValue(text);
@@ -143,6 +145,7 @@ export default App;
 - `disabled?`: boolean
 - `disableArrowIcon?`: boolean
 - `placeholder?`: string;
+- `placeholderTextColor?`: string;
 - `onChangeCountry?`: (country: Country) => void;
 - `onChangeText?`: (text: string) => void;
 - `onChangeFormattedText?`: (text: string) => void;

--- a/lib/index.js
+++ b/lib/index.js
@@ -150,6 +150,7 @@ export default class PhoneInput extends PureComponent {
       textInputStyle,
       autoFocus,
       placeholder,
+      placeholderTextColor,
       disableArrowIcon,
       flagButtonStyle,
       containerStyle,
@@ -222,6 +223,7 @@ export default class PhoneInput extends PureComponent {
             <TextInput
               style={[styles.numberText, textInputStyle ? textInputStyle : {}]}
               placeholder={placeholder ? placeholder : "Phone Number"}
+              placeholderTextColor={placeholderTextColor ? placeholderTextColor : 'rgba(0,0,0,0.35)'}
               onChangeText={this.onChangeText}
               value={number}
               editable={disabled ? false : true}


### PR DESCRIPTION
Hey Anurag!

Thank you so much for this amazing npm package!!

I needed to be able to specify the placeholderTextColor so I thought I'd submit a PR. I made the code so if it's not specified, it falls back to a close approximation of the default placeholder text color, 35% black. I also added the new prop to the README page.

I tried it in my project and it works. Hope you'll consider merging it into your project.

If necessary you can reach me by email: justinschier [at] gmail.com 

Thanks!
Justin Schier
