### PR TITLE
Add dark mode support for dropdown icon.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,8 @@ import CountryPicker, {
 import { PhoneNumberUtil } from "google-libphonenumber";
 import styles from "./styles";
 
+const dropDownWhite = 
+"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAABpSURBVHgB7c7JDcAwDANBleL+m2IpivPN6UOiYYAE+N4x0zRN0+rcvdTDecPZXIXALU5E4DVOQOA3nohAczwBge54IALD8QAEpuMTCITFBxDx8Q5EXrwBkR//QPDiDwh+/IIopmnazjsA9h+ezKBcStUAAAAASUVORK5CYII=";
 const dropDown =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAi0lEQVRYR+3WuQ6AIBRE0eHL1T83FBqU5S1szdiY2NyTKcCAzU/Y3AcBXIALcIF0gRPAsehgugDEXnYQrUC88RIgfpuJ+MRrgFmILN4CjEYU4xJgFKIa1wB6Ec24FuBFiHELwIpQxa0ALUId9wAkhCnuBdQQ5ngP4I9wxXsBDyJ9m+8y/g9wAS7ABW4giBshQZji3AAAAABJRU5ErkJggg==";
 const phoneUtil = PhoneNumberUtil.getInstance();
@@ -118,9 +120,10 @@ export default class PhoneInput extends PureComponent {
   }
 
   renderDropdownImage = () => {
+    const { withDarkTheme } = this.props
     return (
       <Image
-        source={{ uri: dropDown }}
+        source={{ uri: withDarkTheme ? dropDownWhite : dropDown }}
         resizeMode="contain"
         style={styles.dropDownImage}
       />


### PR DESCRIPTION
- Add a white dropdown icon base64 string.
- Show the white dropdown icon when withDarkTheme resolves true instead of the default black.

Fix :- garganurag893#74


![WhatsApp Image 2021-11-01 at 10 01 35 AM (1)](https://user-images.githubusercontent.com/54940154/139623482-d81bf918-64b0-471f-be25-208b32e8d1d3.jpeg)
Before


![WhatsApp Image 2021-11-01 at 10 16 31 AM](https://user-images.githubusercontent.com/54940154/139623481-33a4bf2f-b74e-4a4b-9496-e196d540491c.jpeg)
After