### PR TITLE
The focus method was added

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ export default App;
 - `getCallingCode`: () => string | undefined
 - `getNumberAfterPossiblyEliminatingZero`: () => {number: string , formattedNumber: string };
 - `isValidNumber`: (number: string) => boolean
+- `focus`: () => undefined
 
 ## FAQ
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -298,10 +298,17 @@ export default class PhoneInput extends Component<
     | "AX";
   getCallingCode: () => string | undefined;
   isValidNumber: (number: string) => boolean;
+  focus: () => void;
   onSelect: (country: Country) => void;
-  getNumberAfterPossiblyEliminatingZero: () => {number: string , formattedNumber: string };
+  getNumberAfterPossiblyEliminatingZero: () => {
+    number: string;
+    formattedNumber: string;
+  };
   onChangeText: (text: string) => void;
   render(): JSX.Element;
 }
 
-export function isValidNumber(number: string, countryCode: CountryCode ): boolean;
+export function isValidNumber(
+  number: string,
+  countryCode: CountryCode
+): boolean;

--- a/lib/index.js
+++ b/lib/index.js
@@ -66,6 +66,10 @@ export default class PhoneInput extends PureComponent {
     }
   };
 
+  focus = () => {
+    this.input && this.input.focus();
+  }
+
   onSelect = (country) => {
     const { onChangeCountry } = this.props;
     this.setState(
@@ -230,6 +234,9 @@ export default class PhoneInput extends PureComponent {
               keyboardType="number-pad"
               autoFocus={autoFocus}
               {...textInputProps}
+              ref={(input) => {
+                this.input = input;
+              }}
             />
           </View>
         </View>


### PR DESCRIPTION
Now the developers can use the focus method to focus the input.

Example:
`
      <PhoneInput 
        ref={inputPhone}
      />
     <Button title='focus' onPress={() => inputPhone.current?.focus()} />
`