### PR TITLE
chore: Update Flag button to Pressable

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 import React, { PureComponent } from "react";
-import { View, Text, TouchableOpacity, Image, TextInput } from "react-native";
+import { View, Text, Pressable, Image, TextInput } from "react-native";
 import CountryPicker, {
   getCallingCode,
   DARK_THEME,
@@ -170,7 +170,7 @@ export default class PhoneInput extends PureComponent {
             containerStyle ? containerStyle : {},
           ]}
         >
-          <TouchableOpacity
+          <Pressable
             style={[
               styles.flagButtonView,
               layout === "second" ? styles.flagButtonExtraWidth : {},
@@ -207,7 +207,7 @@ export default class PhoneInput extends PureComponent {
                   : this.renderDropdownImage()}
               </React.Fragment>
             )}
-          </TouchableOpacity>
+          </Pressable>
           <View
             style={[
               styles.textContainer,


### PR DESCRIPTION
Moving to Pressable for buttons is suggested by React Native Team.

Ref: https://reactnative.dev/docs/touchableopacity