### PR TITLE
Replace google-libphonenumber with libphonenumber-js

### DIFF
--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -3253,11 +3253,6 @@ globals@^12.1.0:
   dependencies:
     type-fest "^0.8.1"
 
-google-libphonenumber@^3.2.10:
-  version "3.2.19"
-  resolved "https://registry.yarnpkg.com/google-libphonenumber/-/google-libphonenumber-3.2.19.tgz#4177f9a1232a740cfd378a46f628ae9a62982069"
-  integrity sha512-zevRvpUuc88wIXa+ijlMprAc8SrldUtYY2vQpfymmxyZ2ksct6gFrGxccpo28+zjvjK51VoSUaDUHS24XYp6dA==
-
 graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
   version "4.2.6"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
@@ -4491,6 +4486,11 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+libphonenumber-js@^1.9.49:
+  version "1.9.49"
+  resolved "https://registry.yarnpkg.com/libphonenumber-js/-/libphonenumber-js-1.9.49.tgz#d431703cd699be2ccced5b95f26182a7c50a9227"
+  integrity sha512-/wEOIONcVboFky+lWlCaF7glm1FhBz11M5PHeCApA+xDdVfmhKjHktHS8KjyGxouV5CSXIr4f3GvLSpJa4qMSg==
+
 lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
@@ -5600,9 +5600,9 @@ react-native-country-picker-modal@^2.0.0:
     react-async-hook "3.6.1"
 
 react-native-phone-number-input@../:
-  version "2.0.1"
+  version "2.1.0"
   dependencies:
-    google-libphonenumber "^3.2.10"
+    libphonenumber-js "^1.9.49"
     react-native-country-picker-modal "^2.0.0"
 
 react-native@0.63.0:

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,6 @@ import styles from "./styles";
 
 const dropDown =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAi0lEQVRYR+3WuQ6AIBRE0eHL1T83FBqU5S1szdiY2NyTKcCAzU/Y3AcBXIALcIF0gRPAsehgugDEXnYQrUC88RIgfpuJ+MRrgFmILN4CjEYU4xJgFKIa1wB6Ec24FuBFiHELwIpQxa0ALUId9wAkhCnuBdQQ5ngP4I9wxXsBDyJ9m+8y/g9wAS7ABW4giBshQZji3AAAAABJRU5ErkJggg==";
-const phoneUtil = PhoneNumberUtil.getInstance();
 
 export default class PhoneInput extends PureComponent {
   constructor(props) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,7 @@ import CountryPicker, {
   CountryModalProvider,
   Flag,
 } from "react-native-country-picker-modal";
-import { PhoneNumberUtil } from "google-libphonenumber";
+import { isValidPhoneNumber } from "libphonenumber-js";
 import styles from "./styles";
 
 const dropDown =
@@ -59,8 +59,7 @@ export default class PhoneInput extends PureComponent {
   isValidNumber = (number) => {
     try {
       const { countryCode } = this.state;
-      const parsedNumber = phoneUtil.parse(number, countryCode);
-      return phoneUtil.isValidNumber(parsedNumber);
+      return isValidPhoneNumber(number, countryCode);
     } catch (err) {
       return false;
     }
@@ -240,8 +239,7 @@ export default class PhoneInput extends PureComponent {
 
 export const isValidNumber = (number, countryCode) => {
   try {
-    const parsedNumber = phoneUtil.parse(number, countryCode);
-    return phoneUtil.isValidNumber(parsedNumber);
+    return isValidPhoneNumber(number, countryCode);
   } catch (err) {
     return false;
   }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "android"
   ],
   "dependencies": {
-    "google-libphonenumber": "^3.2.10",
+    "libphonenumber-js": "^1.9.49",
     "react-native-country-picker-modal": "^2.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -700,11 +700,6 @@ globals@^11.1.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
-google-libphonenumber@^3.2.10:
-  version "3.2.10"
-  resolved "https://registry.yarnpkg.com/google-libphonenumber/-/google-libphonenumber-3.2.10.tgz#021a314652747d736a39e2e60dc670f0431425ad"
-  integrity sha512-TsckE9O8QgqaIeaOXPjcJa4/kX3BzFdO1oCbMfmUpRZckml4xJhjJVxaT9Mdt/VrZZkT9lX44eHAEWfJK1tHtw==
-
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
@@ -743,6 +738,11 @@ json5@^2.1.2:
   integrity sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
   dependencies:
     minimist "^1.2.5"
+
+libphonenumber-js@^1.9.49:
+  version "1.9.49"
+  resolved "https://registry.yarnpkg.com/libphonenumber-js/-/libphonenumber-js-1.9.49.tgz#d431703cd699be2ccced5b95f26182a7c50a9227"
+  integrity sha512-/wEOIONcVboFky+lWlCaF7glm1FhBz11M5PHeCApA+xDdVfmhKjHktHS8KjyGxouV5CSXIr4f3GvLSpJa4qMSg==
 
 lodash.toarray@^4.4.0:
   version "4.4.0"


### PR DESCRIPTION
`google-libphonenumber` is a pretty large dependency which adds around 530 kb to the bundle size just for validating a phone number.

This PR replaces this dependency with [libphonenumber-js](https://www.npmjs.com/package/libphonenumber-js) which only takes up around 98kb (81% reduction) while still keeping validation functionality.


### Example project before:
<img width="1411" alt="Screenshot 2022-02-13 at 23 43 44" src="https://user-images.githubusercontent.com/1775259/153778535-d4a53dfc-6408-4f8c-9127-bb2eb2e7db3a.png">
 
### After:
<img width="1408" alt="Screenshot 2022-02-13 at 23 45 07" src="https://user-images.githubusercontent.com/1775259/153778581-38ccbf10-a49a-4e74-ba31-4c974e4f2d43.png">

