### PR TITLE
Registers callbacks for onBlur and onFocus events

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -19,6 +19,8 @@ export interface PhoneInputProps {
   onChangeCountry?: (country: Country) => void;
   onChangeText?: (text: string) => void;
   onChangeFormattedText?: (text: string) => void;
+  onBlur?: () => void;
+  onFocus?: () => void;
   renderDropdownImage?: JSX.Element;
   containerStyle?: StyleProp<ViewStyle>;
   textContainerStyle?: StyleProp<ViewStyle>;
@@ -299,9 +301,15 @@ export default class PhoneInput extends Component<
   getCallingCode: () => string | undefined;
   isValidNumber: (number: string) => boolean;
   onSelect: (country: Country) => void;
-  getNumberAfterPossiblyEliminatingZero: () => {number: string , formattedNumber: string };
+  getNumberAfterPossiblyEliminatingZero: () => {
+    number: string;
+    formattedNumber: string;
+  };
   onChangeText: (text: string) => void;
   render(): JSX.Element;
 }
 
-export function isValidNumber(number: string, countryCode: CountryCode ): boolean;
+export function isValidNumber(
+  number: string,
+  countryCode: CountryCode
+): boolean;

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,13 +32,16 @@ export default class PhoneInput extends PureComponent {
 
   static getDerivedStateFromProps(nextProps, prevState) {
     if (nextProps.disabled !== prevState.disabled) {
-      if ((nextProps.value || nextProps.value === "") && nextProps.value !== prevState.number) {
-        return ({ disabled: nextProps.disabled, number: nextProps.value });
+      if (
+        (nextProps.value || nextProps.value === "") &&
+        nextProps.value !== prevState.number
+      ) {
+        return { disabled: nextProps.disabled, number: nextProps.value };
       }
-      return ({ disabled: nextProps.disabled });
+      return { disabled: nextProps.disabled };
     }
     return null;
-  };
+  }
 
   async componentDidMount() {
     const { defaultCode } = this.props;
@@ -229,6 +232,8 @@ export default class PhoneInput extends PureComponent {
               keyboardAppearance={withDarkTheme ? "dark" : "default"}
               keyboardType="number-pad"
               autoFocus={autoFocus}
+              onBlur={this.props.onBlur}
+              onFocus={this.props.onFocus}
               {...textInputProps}
             />
           </View>


### PR DESCRIPTION
This PR enables users run functions, like style changes e.t.c, when the phone number input is on focus or blur state.

```
             <PhoneInput
                ref={phoneInput}
                layout="first"
                containerStyle={{
                  borderRadius: 10,
                  borderColor: Colors.black,
                  borderWidth: 1,
                }}
                onChangeText={(text) => {
                  setValue(text);
                }}
                onFocus={() => setContainerStyle("containerActive")}
                onBlur={() => setContainerStyle("container")}
                onChangeFormattedText={(text) => {
                  setFormattedValue(text);
                }}
                textContainerStyle={{
                  borderRadius: 10,
                }}
                textInputStyle={{
                  fontFamily: "Rubik_400Regular",
                  color: Colors.black,
                }}
                withShadow
                autoFocus
              /> 
```